### PR TITLE
Add info about gnome-system-logs vs gnome-logs

### DIFF
--- a/xml/release-notes.xml
+++ b/xml/release-notes.xml
@@ -180,6 +180,7 @@
       <listitem><para><literal>cadabra</literal>: the source code no longer builds.
 	  The successor <link xlink:href="http://cadabra.science/">version 2</link>
 	  is not stable yet</para></listitem>
+      <listitem><para><literal>gnome-system-log</literal>: replaced by <literal>gnome-logs</literal></para></listitem>	  
     </itemizedlist>
   </section>
 


### PR DESCRIPTION
https://build.opensuse.org/request/show/390232

gnome-system-logs is deprecated a long time ago, and is now replaced by gnome-logs